### PR TITLE
fix initial docs for reflect plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Each installed plugin loads only its specific agents, commands, and skills into 
 ### Step 3: Use Plugin
 
 ```bash
-# Use it after completing any task
+# Include in your prompt "reflect" word
 > claude "implement user authentication, then reflect"
 
 # Claude implements user authentication, then automatically runs /reflexion:reflect

--- a/docs/plugins/reflexion/README.md
+++ b/docs/plugins/reflexion/README.md
@@ -31,7 +31,7 @@ On top of that, the plugin is based on the [Agentic Context Engineering](https:/
 # Install the plugin
 /plugin install reflexion@NeoLabHQ/context-engineering-kit
 
-# Use it after completing any task
+# Include in your prompt "reflect" word
 > claude "implement user authentication, then reflect"
 
 # Claude implements user authentication, then automatically runs /reflexion:reflect

--- a/plugins/reflexion/README.md
+++ b/plugins/reflexion/README.md
@@ -31,7 +31,7 @@ On top of that, the plugin is based on the [Agentic Context Engineering](https:/
 # Install the plugin
 /plugin install reflexion@NeoLabHQ/context-engineering-kit
 
-# Use it after completing any task
+# Include in your prompt "reflect" word
 > claude "implement user authentication, then reflect"
 
 # Claude implements user authentication, then automatically runs /reflexion:reflect


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Docs update: Reflexion usage clarification**
> 
> - Updates Quick Start in `README.md`, `docs/plugins/reflexion/README.md`, and `plugins/reflexion/README.md` to instruct including the exact word `reflect` in prompts, which auto-triggers `/reflexion:reflect`.
> - No functional or code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9327eaa66a30ac66521ee6d0128e9be9ed575acf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->