### PR TITLE
Fix typo in guidance section of SKILL.md

### DIFF
--- a/plugins/ddd/skills/software-architecture/SKILL.md
+++ b/plugins/ddd/skills/software-architecture/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for quality focused software architecture. This skill should 
 
 # Software Architecture Development Skill
 
-This skill provides guidence for quality focused software development and architecture. It is based on Clean Architecture and Domain Driven Design principles.
+This skill provides guidance for quality focused software development and architecture. It is based on Clean Architecture and Domain Driven Design principles.
 
 ## Code Style Rules
 


### PR DESCRIPTION
The word "guidence" should be "guidance". Shouldn't it?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a spelling error in the software architecture skill documentation.
> 
> - Corrects typo in the introduction of `plugins/ddd/skills/software-architecture/SKILL.md` ("guidence" → "guidance")
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc42a79492f8c37674bb9d2b479577d95dc8321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->