### PR TITLE
🐛 fix: convert agentskills.io to proper markdown link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Marketplace is based on prompts used daily by our company developers for a long 
 
 ## Supported Agents
 
-Universal support based on <agentskills.io> and [openskills](https://github.com/numman-ali/openskills) standards.
+Universal support based on [agentskills.io](https://agentskills.io) and [openskills](https://github.com/numman-ali/openskills) standards.
 
 | Agent | How it works | Status |
 |:------|:-------------|:------:|


### PR DESCRIPTION
Fix the agentskills.io link in the README by converting it from angle bracket notation to proper markdown link syntax to ensure it renders correctly.