### PR TITLE
fix: replace unsupported --version flag with -help in codemap setup skill

### DIFF
--- a/plugins/mcp/skills/setup-codemap-cli/SKILL.md
+++ b/plugins/mcp/skills/setup-codemap-cli/SKILL.md
@@ -35,7 +35,7 @@ Store the user's choice and use the appropriate paths in subsequent steps.
 
 ## 2. Check if Codemap is already installed
 
-Check whether codemap is installed by running `codemap --version` or `codemap --help`.
+Check whether codemap is installed by running `codemap -help`.
 
 If not installed, proceed with setup.
 
@@ -65,7 +65,6 @@ scoop install codemap
 After installation, verify codemap works:
 
 ```bash
-codemap --version
 codemap .
 ```
 


### PR DESCRIPTION
## Summary

- Replace `codemap --version` with `codemap -help` for installation detection (step 2)
- Remove `codemap --version` from verification step (step 5), keep only `codemap .`

## Problem

The `mcp:setup-codemap-cli` skill uses `codemap --version` to check if codemap is installed and to verify the installation. However, codemap is a Go binary using Go's `flag` package and does **not** implement a `--version` flag. This causes an exit code 2 error:

```
Error: Exit code 2
flag provided but not defined: -version
```

The setup still works because the agent sees the usage output and infers codemap is installed, but it produces a confusing error message.

## Fix

- **Step 2** (detection): `codemap --version` → `codemap -help`
- **Step 5** (verification): removed `codemap --version`, kept `codemap .` which is a reliable functional test