### PR TITLE
fix(review-pr): always leave a final verdict when no issues found

### DIFF
--- a/plugins/review/skills/review-pr/SKILL.md
+++ b/plugins/review/skills/review-pr/SKILL.md
@@ -276,7 +276,15 @@ When using `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments`, post just o
 
 #### If you found no issues
 
-Do not post any comments. Simply report to the user that no issues were found.
+Do not post inline review comments. But you MUST still end with a clear final
+verdict in the sticky progress comment — never leave it on the interim
+"I'll analyze this and get back to you" placeholder. Finish with a short line
+such as:
+
+> ✅ Reviewed — no issues found.
+
+This is the tracking/sticky comment, not a separate overall review report, so it
+does not violate the "inline comments only" rule above.
 
 ## Remember
 


### PR DESCRIPTION
## Problem

The `/review-pr` skill runs via `claude-code-action` with `track_progress: true` + `use_sticky_comment: true` (see `devops/.github/actions/agent-review`). When a PR is clean, the skill said:

> If you found no issues → Do not post any comments. Simply report to the user that no issues were found.

So the reviewer posted nothing, and the sticky progress comment stayed stuck on the interim **"I'll analyze this and get back to you"** placeholder. Reviewers/authors saw a finished-but-empty comment and couldn't tell the PR was actually reviewed and clean.

Observed on `cloudbankin-data-export` PR #258 (dev→master): review ran all 6 agents, `No buffered inline comments`, but the sticky comment never got a verdict.

## Fix

Change the "no issues" instruction: still no inline comments, but **always end with a short final verdict in the sticky comment** (e.g. `✅ Reviewed — no issues found.`), clarified as the tracking/sticky comment rather than a separate overall review report (so it doesn't conflict with the "inline comments only" rule).

Scope: only `review-pr` (it posts to the PR). `review-local-changes` is unchanged — it reports locally and has no sticky comment.