### PR TITLE
feat: add logic to avoid iterating on nitpicks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "context-engineering-kit",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Hand-crafted collection of advanced context engineering techniques and patterns with minimal token footprint focused on improving agent result quality.",
   "owner": {
     "name": "NeoLabHQ",
@@ -55,7 +55,7 @@
     {
       "name": "sadd",
       "description": "Introduces skills for subagent-driven development, dispatches fresh subagent for each task with code review between tasks, enabling fast iteration with quality gates.",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "author": {
         "name": "Vlad Goncharov",
         "email": "vlad.goncharov@neolab.finance"
@@ -77,7 +77,7 @@
     {
       "name": "sdd",
       "description": "Specification Driven Development workflow commands and agents, based on Github Spec Kit and OpenSpec. Uses specialized agents for effective context management and quality review.",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "author": {
         "name": "Vlad Goncharov",
         "email": "vlad.goncharov@neolab.finance"

--- a/.claude/rules/refactor-cross-references.md
+++ b/.claude/rules/refactor-cross-references.md
@@ -5,7 +5,7 @@ impact: HIGH
 
 # Update All Cross-References When Refactoring Numbered Sequences
 
-When removing or renumbering a numbered element (gate, step, section, list item), grep the ENTIRE file for ALL derived references to the old range/count — not just the obvious primary block — and update every cross-reference. Adjacent checklists, template comments, and action items often reference the old count and become silently inconsistent.
+When removing or renumbering a numbered element (gate, step, section, list item), **or introducing a numeric bound that tightens an existing one** (a new floor, cap, or threshold), grep the ENTIRE file for ALL derived references to the old range/count — not just the obvious primary block — and update every cross-reference. Adjacent checklists, legends, template comments, and action items often restate the old, looser range and become silently inconsistent.
 
 ## Incorrect
 

--- a/docs/plugins/sadd/do-and-judge.md
+++ b/docs/plugins/sadd/do-and-judge.md
@@ -13,7 +13,16 @@ Three-layer verification:
 - meta-judge criteria (structured) 
 - LLM-as-a-judge (external)
 
-Iteration - Retry with judge feedback until passing (score >=4, or >=3.0 with all low-priority issues) or max retries (3)
+Iteration - Retry with judge feedback until passing (score >=4, or >=3.0 with all low/medium priority issues) or max retries (3)
+
+## Arguments
+
+| Argument | Format | Default | Description |
+|----------|--------|---------|-------------|
+| `task` | Free-form text | **Required** | Task description to execute |
+| `--model` | `opus|sonnet|haiku` | `opus` | Model to use for the implementation, meta-judge and judge |
+| `--strict` | flag | `false` | Disable iteration discretion — the task passes ONLY at score >= 4.0, otherwise retry until max retries |
+
 
 ## Pattern: Single-Task Execution with Meta-Judge and Judge Verification
 
@@ -55,6 +64,9 @@ Phase 5: Final Report or Escalation
 
 # Architecture change
 /do-and-judge "Extract validation logic from UserController into separate UserValidator class"
+
+# Never accept a result below target quality
+/do-and-judge "Refactor the UserService class to use dependency injection" --strict
 ```
 
 ## When to Use

--- a/docs/plugins/sadd/do-in-parallel.md
+++ b/docs/plugins/sadd/do-in-parallel.md
@@ -150,7 +150,19 @@ Phase 6: Collect and Summarize Results
 /do-in-parallel "Security audit for injection vulnerabilities" \
   --files "src/db/queries.ts,src/api/search.ts" \
   --model opus
+
+# Never accept a target below target quality
+/do-in-parallel "Simplify error handling to use early returns" \
+  --files "src/services/user.ts,src/services/order.ts" \
+  --strict
 ```
+
+| Argument | Format | Default | Description |
+|----------|--------|---------|-------------|
+| `--files` | `--files "a.ts,b.ts"` | Inferred | File-based targets |
+| `--targets` | `--targets "A,B"` | Inferred | Named targets |
+| `--model` | `opus\|sonnet\|haiku` | Auto-selected | Model override for implementation agents |
+| `--strict` | flag | `false` | Disable iteration discretion — a target passes ONLY at score >= 4.0, otherwise retry until max retries |
 
 ## When to Use
 
@@ -188,7 +200,7 @@ Each implementation agent is then verified by an independent `sadd:judge` agent 
 |--------|---------|
 | **Meta-Judge** | `sadd:meta-judge` (Opus) dispatched per group or independent task, all in parallel |
 | **Judge** | `sadd:judge` (Opus) per target (independent/repeatable) or per group (shared) |
-| **Threshold** | Score >=4/5.0 for PASS; soft PASS at >=3 if all issues are low priority |
+| **Threshold** | Score >=4/5.0 for PASS; soft PASS at >=3 if all issues are low/medium priority |
 | **Max Retries** | 3 retries per target (same meta-judge spec reused on retries) |
 | **Isolation** | Each target's failure doesn't affect others |
 | **Feedback Loop** | Judge ISSUES passed to retry implementation |

--- a/docs/plugins/sadd/do-in-steps.md
+++ b/docs/plugins/sadd/do-in-steps.md
@@ -11,6 +11,14 @@ Execute complex tasks through sequential sub-agent orchestration with intelligen
 
 Three-layer verification: self-critique (internal) + meta-judge evaluation spec (per step) + LLM-as-a-judge (external) with iteration until passing
 
+## Arguments
+
+| Argument | Format | Default | Description |
+|----------|--------|---------|-------------|
+| `task` | Free-form text | **Required** | Task description to decompose and execute |
+| `--model` | `opus|sonnet|haiku` | `opus` | Model to use for the implementation, meta-judge and judge |
+| `--strict` | flag | `false` | Disable iteration discretion — a step passes ONLY at score >= 4.0, otherwise retry until max retries |
+
 ## Pattern: Sequential Orchestration with Meta-Judge and Judge Verification
 
 ```
@@ -66,6 +74,9 @@ Phase 4: Final Summary and Report
 
 # Multi-file refactoring with breaking changes
 /do-in-steps "Rename 'userId' to 'accountId' across the codebase - affects interfaces, implementations, and callers"
+
+# Never accept a step below target quality
+/do-in-steps "Add email notification capability to the order processing system" --strict
 ```
 
 ## When to Use

--- a/docs/plugins/sdd/customization.md
+++ b/docs/plugins/sdd/customization.md
@@ -10,6 +10,8 @@ In contrast to other plugins in the context-engineering-kit marketplace, this pl
 
 If you want better results or want to finish tasks faster, you can adjust command parameters. For example, adding `--target-quality 4.5 --max-iterations 5` to `/plan` or `/implement` allows the orchestrator agent to iterate more toward "ideal" results. Conversely, setting `--target-quality 3.0 --max-iterations 1` makes agents finish when results minimally meet the criteria, iterating only once to resolve issues. This lets you configure each command to balance quality and speed per task run.
 
+Note that `target-quality` is a target, not a hard stop: by default the orchestrator may accept a phase or step that lands slightly below it when the only outstanding issues are Low/Medium nitpicks that break no requirement (see Iteration Discretion in the `/plan` and `/implement` docs), and it reports those issues in the summary. Add `--strict` when the target is non-negotiable — the orchestrator then stops only at `target-quality` or `max-iterations`, at the cost of extra iterations.
+
 If you just want results as fast as the framework can produce them, use the `--fast` preset in the `/plan` command. It limits the number of steps and decreases both target quality and refinement iterations altogether.
 
 If you know certain steps aren't needed for your task, you can use the `--skip` parameter in the `/plan` command. For example, `--skip research` skips the research phase entirely, and `--skip parallelize` skips task parallelization.

--- a/docs/plugins/sdd/implement-task.md
+++ b/docs/plugins/sdd/implement-task.md
@@ -17,9 +17,11 @@ Execute task implementation steps using automated LLM-as-Judge quality verificat
 | `--target-quality` | `--target-quality X.X` or `X.X,Y.Y` | `4.0` (standard) / `4.5` (critical) | Quality threshold. Single value sets both. Two comma-separated values set standard,critical. |
 | `--max-iterations` | `--max-iterations N` | `3` | Maximum fix→verify cycles per step. Set to `unlimited` for no limit. |
 | `--human-in-the-loop` | `--human-in-the-loop [s1,s2,...]` | None | Steps after which to pause for review. If no steps are specified, the process pauses after every step. |
-| `--skip-judges` | flag | `false` | Skip all judge validation — fast but provides no quality gates |
+| `--skip-reviews` | flag | `false` | Skip all per-step code-reviewer checks — fast but provides no quality gates |
 | `--continue` | flag | None | Resume from the last completed step |
 | `--refine` | flag | `false` | Detect changed project files and re-verify from the earliest affected step |
+| `--strict` | flag | `false` | Disable iteration discretion — a step passes ONLY when its score reaches the threshold, otherwise iterate until `--max-iterations` |
+
 
 ## Context Management
 
@@ -224,7 +226,10 @@ After each specified step passes:
 /implement-task add-validation.feature.md --max-iterations unlimited
 
 # Skip judges for fast execution (no quality gates)
-/implement-task add-validation.feature.md --skip-judges
+/implement-task add-validation.feature.md --skip-reviews
+
+# Never accept a step below target quality
+/implement-task add-validation.feature.md --strict
 
 # Combined: continue with human review
 /implement-task add-validation.feature.md --continue --human-in-the-loop
@@ -245,4 +250,5 @@ After each specified step passes:
 - Use `--refine` after making manual fixes — it re-verifies affected steps without re-implementing everything
 - For critical features, use `--target-quality 4.5` to enforce stricter quality
 - Use `--human-in-the-loop` for high-risk implementations where you want to review each step
-- Use `--skip-judges` only for well-understood tasks where speed matters more than verification
+- Use `--skip-reviews` only for well-understood tasks where speed matters more than verification
+- Use `--strict` when the target quality is non-negotiable and you accept the extra iterations it costs

--- a/docs/plugins/sdd/plan-task.md
+++ b/docs/plugins/sdd/plan-task.md
@@ -24,6 +24,8 @@ Refine a draft task specification into a fully planned, implementation-ready tas
 | `--skip-judges` | flag | `false` | Skip all judge validation checks |
 | `--refine` | flag | `false` | Detect changes via git diff and re-run only affected stages |
 | `--continue` | `--continue [stage]` | None | Resume from a specific stage (auto-detects if stage not provided) |
+| `--model` | `opus|sonnet|haiku` | `opus` | Model to use for the agents and judges |
+| `--strict` | flag | `false` | Disable iteration discretion — a phase passes ONLY when its score reaches the threshold, otherwise retry until `--max-iterations` |
 
 ## Stage Names
 
@@ -144,8 +146,10 @@ Moves the refined task file from `draft/` to `todo/` and stages all generated ar
 Every phase includes a judge validation step using LLM-as-Judge:
 
 - **PASS** (score >= threshold) — Phase complete; proceed to the next stage.
+- **ACCEPTED** (score below threshold but at or above the floor) — Accepted because of only low/medium priority issues, all target requirements are met.
 - **FAIL** (score < threshold) — Re-run the phase with judge feedback.
 - **MAX_ITERATIONS reached** — Proceed to the next stage automatically (with a warning logged).
+
 
 ## Refine Mode (`--refine`)
 
@@ -190,6 +194,9 @@ You can also pass a requirement change directly: `/plan --refine <requirement ch
 
 # Incremental refinement after editing the spec
 /plan-task .specs/tasks/todo/my-task.feature.md --refine
+
+# Never accept a phase below target quality
+/plan-task .specs/tasks/draft/critical-api.feature.md --strict
 ```
 
 ## Artifacts Generated

--- a/plugins/sadd/.claude-plugin/plugin.json
+++ b/plugins/sadd/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sadd",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Introduces skills for subagent-driven development, dispatches fresh subagent for each task with code review between tasks, enabling fast iteration with quality gates.",
   "author": {
     "name": "Vlad Goncharov",

--- a/plugins/sadd/skills/do-and-judge/SKILL.md
+++ b/plugins/sadd/skills/do-and-judge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do-and-judge
 description: Execute a task with sub-agent implementation and LLM-as-a-judge verification with automatic retry loop
-argument-hint: Task description (e.g., "Refactor the UserService class to use dependency injection")
+argument-hint: Task description [--model opus|sonnet|haiku] [--strict] (e.g., "Refactor the UserService class to use dependency injection")
 ---
 
 # do-and-judge
@@ -9,8 +9,18 @@ argument-hint: Task description (e.g., "Refactor the UserService class to use de
 ## Task
 Execute a single task by dispatching an implementation sub-agent, verifying with an independent judge, and iterating with feedback until passing or max retries exceeded.
 
+## Arguments
+
+| Argument | Format | Default | Description |
+|----------|--------|---------|-------------|
+| `task` | Free-form text | **Required** | Task description to execute |
+| `--model` | `opus|sonnet|haiku` | `opus` | Model to use for the implementation, meta-judge and judge |
+| `--strict` | `--strict` | `false` | Disable the [Iteration Discretion Rule](#iteration-discretion-rule) - the task passes ONLY when `score >= 4.0`, otherwise retry until max retries is reached. |
+
+Example: `/do-and-judge Refactor the UserService class to use dependency injection --strict`
+
 ## Context
-This command implements a **single-task execution pattern** with **meta-judge → LLM-as-a-judge verification**. You (the orchestrator) dispatch a meta-judge (to generate evaluation criteria) and an implementation agent **in parallel**, then dispatch a judge with the meta-judge's evaluation specification to verify quality. If verification fails, you launch new implementation agent with judge feedback and iterate until passing (score ≥4) or max retries (2) exceeded.
+This command implements a **single-task execution pattern** with **meta-judge → LLM-as-a-judge verification**. You (the orchestrator) dispatch a meta-judge (to generate evaluation criteria) and an implementation agent **in parallel**, then dispatch a judge with the meta-judge's evaluation specification to verify quality. If verification fails, you launch new implementation agent with judge feedback and iterate until passing (score ≥4, or accepted per the [Iteration Discretion Rule](#iteration-discretion-rule)) or max retries (3) exceeded.
 
 Key benefits:
 
@@ -26,7 +36,7 @@ Key benefits:
 1. Analyze the task and select optimal model
 2. Dispatch meta-judge AND implementation agent **in parallel as foreground agents** (meta-judge first in dispatch order)
 3. Dispatch judge agent with meta-judge's evaluation specification
-4. Parse verdict and iterate if needed (max 2 retries)
+4. Parse verdict and iterate if needed (max 3 retries)
 5. Report final results or escalate
 
 ## RED FLAGS - Never Do These
@@ -52,6 +62,8 @@ Key benefits:
 ## Process
 
 ### Phase 1: Task Analysis and Model Selection
+
+Resolve configuration first: `STRICT_MODE = --strict present || false`. Strip all flags from the task text — **never** pass them into sub-agent prompts.
 
 Analyze the task to select the optimal model:
 
@@ -353,12 +365,12 @@ If score ≥4:
   → Report success with summary
   → Include IMPROVEMENTS as optional enhancements
 
-IF score ≥ 3.0 and all found issues are low priority, then:
-  → VERDICT: PASS
-  → Report success with summary
-  → Include IMPROVEMENTS as optional enhancements
+If 3.0 ≤ score <4 and NOT STRICT_MODE:
+  → Apply the Iteration Discretion Rule below
+    → accepted → VERDICT: PASS (report outstanding issues)
+    → declined → VERDICT: FAIL → go to "Check retry count" below
 
-If score <4:
+Otherwise (score <3.0, or score <4 with STRICT_MODE):
   → VERDICT: FAIL
   → Check retry count
 
@@ -370,6 +382,22 @@ If score <4:
     → Escalate to user (see Error Handling)
     → Do NOT proceed without user decision
 ```
+
+#### Iteration Discretion Rule
+
+Your main task is to COMPLETE the task within target quality. Two failure modes are equally real:
+
+- Burning retries and context on nitpicks so the task never completes on time → **the task is failed**; a developer is waiting on this result and may have dependent work blocked, so implementation effort MUST stay proportionate to the task's size.
+- Reporting a result whose quality is genuinely too poor to be considered complete → **an even worse failure**.
+
+Apply to every judge score:
+
+- **`score < 3.0` → FAIL, unconditionally. No discretion.** Retry with judge feedback until it passes or max retries is reached.
+- **`3.0 <= score < 4.0` → discretion band.** ONLY inside this band MAY you decide that a result below the `4.0` target is acceptable. The fixed `4.0` target puts the effective floor at `3.0`, so no separate bounded-drop guard is needed.
+- Inside the band, when the outstanding issues are ONLY low/medium priority (any High or Critical finding removes discretion entirely) AND none of them breaks a target requirement of the task or causes a meaningful defect (i.e. they are nitpicks), you MUST reason FIRST — before dispatching a retry — about whether another attempt is worth the developer's time and your context.
+- **At most ONE nitpick-driven retry**, and it counts against the retry budget. If it again surfaces only nitpicks, you MUST report PASS (☑️ ACCEPTED) with the outstanding issues listed in the final report. If it returns a score below `3.0`, the unconditional-FAIL rule applies instead.
+- You MUST be critical, NOT lenient. Stopping short of target MUST be an intentional decision grounded in the absence of real, requirement-breaking issues. A genuine blocking issue that prevents completing the task within max retries MUST be escalated as a failure, never papered over.
+- **If `STRICT_MODE` is true, this whole rule is DISABLED**: stop only when `score >= 4.0` or max retries is reached. `--strict` changes nothing else — the `4.0` target, the max-retry limit, the `< 3.0` unconditional FAIL and meta-judge/judge dispatch are unaffected.
 
 ### Phase 5: Retry with Feedback (If Needed)
 
@@ -413,13 +441,17 @@ After task passes verification:
 ## Execution Summary
 
 **Task:** {original task description}
-**Result:** ✅ PASS
+**Result:** ✅ PASS (or ☑️ ACCEPTED below target per the Iteration Discretion Rule)
+**Strict Mode:** {STRICT_MODE}
 
 ### Verification
 | Attempt | Score | Status |
 |---------|-------|--------|
-| 1 | {X.X}/5.0 | {PASS/FAIL} |
-| 2 | {X.X}/5.0 | {PASS/FAIL} | (if retry occurred)
+| 1 | {X.X}/5.0 | {PASS/ACCEPTED/FAIL} |
+| {N} | {X.X}/5.0 | {PASS/ACCEPTED/FAIL} | (one row per retry that occurred, up to 3)
+
+### Outstanding Issues (if accepted below target)
+{Nitpicks left unresolved, with priority — omit this section when score >= 4.0}
 
 ### Files Modified
 - {file1}: {what changed}
@@ -437,7 +469,7 @@ After task passes verification:
 
 ### If Max Retries Exceeded
 
-When task fails verification twice:
+When the task still fails verification after 3 retries:
 
 1. **STOP** - Do not proceed
 2. **Report** - Provide failure analysis:
@@ -1105,7 +1137,7 @@ Phase 6: Final Report
 - **Never skip meta-judge** - Tailored evaluation criteria produce better judgments than generic ones
 - **Reuse meta-judge spec on retries** - The evaluation specification stays constant across retry attempts; only the implementation changes
 - **Parse only headers from judge** - Don't read full reports to avoid context pollution
-- **Trust the threshold** - 4/5.0 is the quality gate
+- **Trust the threshold** - 4/5.0 is the quality gate; below it, the [Iteration Discretion Rule](#iteration-discretion-rule) decides (unless `--strict`)
 - **Include CLAUDE_PLUGIN_ROOT** - Both meta-judge and judge need the resolved plugin root path
 
 ### Iteration
@@ -1114,6 +1146,7 @@ Phase 6: Final Report
 - **Pass feedback verbatim** - Let the implementation agent see exact issues
 - **Same meta-judge spec** - Do NOT re-run meta-judge on retries; the evaluation criteria don't change
 - **Escalate appropriately** - Don't loop forever on fundamental problems
+- **Stay proportionate** - Match iteration effort to task size per the [Iteration Discretion Rule](#iteration-discretion-rule); at most ONE nitpick-driven retry
 
 ### Context Management
 

--- a/plugins/sadd/skills/do-in-parallel/SKILL.md
+++ b/plugins/sadd/skills/do-in-parallel/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do-in-parallel
 description: Run independent tasks concurrently across multiple files or targets using parallel sub-agents, with per-task model selection and LLM-as-a-judge verification. Use when tasks do not depend on each other and can run side by side.
-argument-hint: Task description [--files "file1.ts,file2.ts,..."] [--targets "target1,target2,..."] [--model opus|sonnet|haiku] [--output <path>]
+argument-hint: Task description [--files "file1.ts,file2.ts,..."] [--targets "target1,target2,..."] [--model opus|sonnet|haiku] [--output <path>] [--strict]
 ---
 
 # do-in-parallel
@@ -68,6 +68,7 @@ Key benefits:
 - Wait for each implementation to complete before dispatching its judge
 - Parse only VERDICT/SCORE/ISSUES from judge output
 - Iterate with feedback if verification fails (max 3 retries per target)
+- Apply the [Iteration Discretion Rule](#55-iteration-discretion-rule) to every target verdict, unless `--strict` was provided
 - For shared group retries, only re-launch the specific failing implementation agent(s), not the entire group
 - Reuse same meta-judge specification for all retries (never re-run meta-judge)
 
@@ -88,6 +89,10 @@ Input patterns:
 - If `--files` provided: Split by comma, validate each path exists
 - If `--targets` provided: Split by comma, use as-is
 - If neither: Attempt to extract file paths or target names from task description
+- `STRICT_MODE = --strict present || false` - disables the [Iteration Discretion Rule](#55-iteration-discretion-rule); a target then passes ONLY when `score >= 4.0`, otherwise it is retried until max retries
+- Strip ALL flags from the task text before building sub-agent prompts — **never** pass them into a sub-agent prompt
+
+Example: `/do-in-parallel Simplify error handling --files "src/a.ts,src/b.ts" --strict`
 
 ### Phase 2: Task Analysis with Zero-shot CoT
 
@@ -773,12 +778,12 @@ If score >= 4:
   -> Mark target complete
   -> Include IMPROVEMENTS as optional enhancements
 
-IF score >= 3.0 and all found issues are low priority, then:
-  -> VERDICT: PASS
-  -> Mark target complete
-  -> Include IMPROVEMENTS as optional enhancements
+If 3.0 <= score < 4 and NOT STRICT_MODE:
+  -> Apply the Iteration Discretion Rule (5.5)
+     -> accepted -> VERDICT: PASS (mark target complete, report outstanding issues)
+     -> declined -> VERDICT: FAIL -> go to "Check retry count" below
 
-If score < 4:
+Otherwise (score < 3.0, or score < 4 with STRICT_MODE):
   -> VERDICT: FAIL
   -> Check retry count for this target
 
@@ -863,6 +868,22 @@ Let's fix the identified issues step by step.
 CRITICAL: Focus on fixing the specific issues identified. Do not rewrite everything.
 ```
 
+#### 5.5 Iteration Discretion Rule
+
+Your main task is to COMPLETE the task within target quality, and iteration effort MUST stay proportionate to each target's size. Two failure modes are equally real:
+
+- Burning retries and context on nitpicks so the overall batch never completes → **the task is failed**.
+- Accepting a target whose quality is genuinely too poor to be considered complete → **an even worse failure**.
+
+Apply to every judge score (for shared groups, apply this per task verdict inside the group):
+
+- **`score < 3.0` → FAIL, unconditionally. No discretion.** Retry with judge feedback until the target passes or max retries is reached.
+- **`3.0 <= score < 4.0` → discretion band.** ONLY inside this band MAY you decide that a target below the `4.0` target score is acceptable. The fixed `4.0` target puts the effective floor at `3.0`, so no separate bounded-drop guard is needed.
+- Inside the band, when the outstanding issues are ONLY low/medium priority (any High or Critical finding removes discretion entirely) AND none of them breaks a target requirement or causes a meaningful defect (i.e. they are nitpicks), you MUST reason FIRST — before dispatching a retry — about whether another attempt is worth the time and context cost.
+- **At most ONE nitpick-driven retry**, and it counts against the retry budget. If it again surfaces only nitpicks, you MUST mark the target complete (`ACCEPTED`), report the outstanding issues in the final summary, and move on. If it returns a score below `3.0`, the unconditional-FAIL rule applies instead.
+- You MUST be critical, NOT lenient. Stopping short of target MUST be an intentional decision grounded in the absence of real, requirement-breaking issues. A genuine blocking issue that prevents completing the target within max retries MUST be reported as a failed target, never papered over.
+- **If `STRICT_MODE` is true, this whole rule is DISABLED**: stop only when `score >= 4.0` or max retries is reached. `--strict` changes nothing else — the `4.0` target score, the max-retry limit, the `< 3.0` unconditional FAIL and meta-judge/judge dispatch are unaffected.
+
 ### Phase 6: Collect and Summarize Results
 
 After all agents complete (with retries as needed), aggregate results:
@@ -874,6 +895,7 @@ After all agents complete (with retries as needed), aggregate results:
 - **Task:** {task description}
 - **Model:** {selected model}
 - **Targets:** {count} items
+- **Strict Mode:** {STRICT_MODE}
 
 ### Results
 
@@ -883,6 +905,8 @@ After all agents complete (with retries as needed), aggregate results:
 | {target_2} | {Repeatable/Shared/Independent} | {model} | {X.X}/5.0 | {0-3} | SUCCESS | {brief outcome} |
 | {target_3} | {Repeatable/Shared/Independent} | {model} | {X.X}/5.0 | {3} | FAILED | {failure reason} |
 | ... | ... | ... | ... | ... | ... | ... |
+
+Status is `SUCCESS` (score >= 4.0), `ACCEPTED` (below target per the [Iteration Discretion Rule](#55-iteration-discretion-rule) — list the outstanding nitpicks in the Verification Summary), or `FAILED`.
 
 ### Overall Assessment
 - **Completed:** {X}/{total}
@@ -2187,6 +2211,7 @@ Use Task tool:
 - **Target-specific meta-judge specification:** Each target gets tailored rubrics that account for its unique characteristics, producing more precise evaluation criteria
 - **External judge second:** Independent judge applies target-specific meta-judge specification mechanically — catches blind spots self-critique misses
 - **Iteration loop:** Retry with feedback until passing or max retries
+- **Proportionate iteration:** Apply the [Iteration Discretion Rule](#55-iteration-discretion-rule) — at most ONE nitpick-driven retry, never below `3.0`, disabled by `--strict`
 - **Isolated failures:** One target failing doesn't affect others
 - **Review the summary:** Check for failed or partial completions
 - **Run tests after:** Parallel changes may have subtle interactions
@@ -2196,7 +2221,7 @@ Use Task tool:
 
 | Failure Type | Description | Recovery Action |
 |--------------|-------------|-----------------|
-| **Recoverable** | Judge found issues, retry available | Retry with judge feedback (max 3 per target) |
+| **Recoverable** | Judge found issues, retry available | Retry with judge feedback (max 3 per target), subject to the [Iteration Discretion Rule](#55-iteration-discretion-rule) |
 | **Approach Failure** | The approach for this target is wrong | Escalate to user with options |
 | **Foundation Issue** | Requirements unclear or impossible | Escalate to user for clarification |
 | **Max Retries Exceeded** | Target failed after 3 retries | Mark failed, continue other targets, report at end |

--- a/plugins/sadd/skills/do-in-steps/SKILL.md
+++ b/plugins/sadd/skills/do-in-steps/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do-in-steps
 description: Execute one complex task as ordered, dependent steps run sequentially, passing context from each step to the next, with per-step LLM-as-a-judge verification. Use when later steps depend on the results of earlier ones.
-argument-hint: Task description (e.g., "Refactor UserService class and update all consumers")
+argument-hint: Task description [--model opus|sonnet|haiku] [--strict] (e.g., "Refactor UserService class and update all consumers")
 ---
 
 # do-in-steps
@@ -22,6 +22,16 @@ This command implements the **Supervisor/Orchestrator pattern** for sequential t
 - **Parallel speed** - Meta-judge and implementation agent run in parallel per step; meta-judge specification reused across retries within that step
 
 </context>
+
+## Arguments
+
+| Argument | Format | Default | Description |
+|----------|--------|---------|-------------|
+| `task` | Free-form text | **Required** | Task description to decompose and execute |
+| `--strict` | `--strict` | `false` | Disable the [Iteration Discretion Rule](#36-iteration-discretion-rule) - a step passes ONLY when `score >= 4.0`, otherwise retry until max retries is reached. |
+| `--model` | `opus|sonnet|haiku` | `opus` | Model to use for the implementation, meta-judge and judge |
+
+Example: `/do-in-steps Refactor UserService class and update all consumers --strict`
 
 **CRITICAL:** You are the orchestrator only - you MUST NOT perform the task yourself. IF you read, write or run bash tools you failed task imidiatly. It is single most critical criteria for you. If you used anyting except sub-agents you will be killed immediatly!!!! Your role is to:
 
@@ -59,6 +69,7 @@ This command implements the **Supervisor/Orchestrator pattern** for sequential t
 - Pass only necessary context summaries, not full file contents
 - Get pass from judge verification before proceeding to next step
 - Iterate with judge feedback if verification fails (max 3 retries)
+- Apply the [Iteration Discretion Rule](#36-iteration-discretion-rule) to every step verdict, unless `--strict` was provided
 
 Any deviation from orchestration (attempting to implement subtasks yourself, reading implementation files, reading full judge reports, or making direct changes) will result in context pollution and ultimate failure, as a result you will be fired!
 
@@ -83,6 +94,8 @@ Where:
 **Note:** Implementation outputs go to their specified locations; only judge verification reports go to `.specs/reports/`
 
 ### Phase 1: Task Analysis and Decomposition
+
+Resolve configuration first: `STRICT_MODE = --strict present || false`. Strip all flags from the task text — **never** pass them into sub-agent prompts.
 
 Analyze the task systematically using Zero-shot Chain-of-Thought reasoning:
 
@@ -257,14 +270,14 @@ Execute subtasks one by one. For each step, dispatch a meta-judge AND implementa
 │   │ Implementer  │──┘   └──────────────┘     └──────────────────────┘       │
 │   │ (Sub-agent)  │                                      │                    │
 │   └──────────────┘                                      ▼                    │
-│          ▲                              ┌─────────────────────────┐          │
-│          │                              │ PASS (≥4.0)?            │          │
-│          │                              │ ├─ YES → Next Step      │          │
-│          │                              │ ├─ ≥3.0 + low → PASS   │          │
-│          │                              │ └─ NO  → Retry?         │          │
-│          │                              │     ├─ <3 → Retry       │          │
-│          │                              │     └─ ≥3 → Escalate    │          │
-│          │                              └─────────────────────────┘          │
+│          ▲                              ┌──────────────────────────────┐     │
+│          │                              │ PASS (≥4.0)?                 │     │
+│          │                              │ ├─ YES → Next Step           │     │
+│          │                              │ ├─ ≥3.0 → Rule 3.6           │     │
+│          │                              │ └─ NO  → Retry?              │     │
+│          │                              │     ├─ <3 retries → Retry    │     │
+│          │                              │     └─ ≥3 retries → Escalate │     │
+│          │                              └──────────────────────────────┘     │
 │          │                                            │                      │
 │          └────────────── feedback ────────────────────┘                      │
 │          (retries reuse same meta-judge spec, no new meta-judge)             │
@@ -643,12 +656,12 @@ For each subtask in sequence:
      → Proceed to next step with accumulated context
      → Include IMPROVEMENTS in context as optional enhancements
 
-   IF score ≥ 3.0 and all found issues are low priority, then:
-     → VERDICT: PASS
-     → Proceed to next step with accumulated context
-     → Include IMPROVEMENTS in context as optional enhancements
+   If 3.0 ≤ score <4.0 and NOT STRICT_MODE:
+     → Apply the Iteration Discretion Rule (3.6)
+       → accepted → VERDICT: PASS (report outstanding issues and proceed)
+       → declined → VERDICT: FAIL → go to "Check retry count" below
 
-   If score <4.0:
+   Otherwise (score <3.0, or score <4.0 with STRICT_MODE):
      → VERDICT: FAIL
      → Check retry count for this step
 
@@ -706,6 +719,22 @@ Let's fix the identified issues step by step.
 CRITICAL: Focus on fixing the specific issues identified. Do not rewrite everything.
 ```
 
+#### 3.6 Iteration Discretion Rule
+
+Your main task is to COMPLETE the task within target quality, and iteration effort MUST stay proportionate to each step's size. Two failure modes are equally real:
+
+- Burning retries and context on nitpicks so the overall task never completes → **the task is failed**.
+- Accepting a step whose quality is genuinely too poor to be considered complete → **an even worse failure**.
+
+Apply to every judge score:
+
+- **`score < 3.0` → FAIL, unconditionally. No discretion.** Retry with judge feedback until the step passes or max retries is reached.
+- **`3.0 <= score < 4.0` → discretion band.** ONLY inside this band MAY you decide that a step below the `4.0` target is acceptable. The fixed `4.0` target puts the effective floor at `3.0`, so no separate bounded-drop guard is needed.
+- Inside the band, when the outstanding issues are ONLY low/medium priority (any High or Critical finding removes discretion entirely) AND none of them breaks a target requirement of the step or causes a meaningful defect (i.e. they are nitpicks), you MUST reason FIRST — before dispatching a retry — about whether another attempt is worth the time and context cost.
+- **At most ONE nitpick-driven retry**, and it counts against the retry budget. If it again surfaces only nitpicks, you MUST mark the step PASS (`ACCEPTED`), carry the outstanding issues forward in the accumulated context, report them in the final summary, and continue with the next step. If it returns a score below `3.0`, the unconditional-FAIL rule applies instead.
+- You MUST be critical, NOT lenient. Stopping short of target MUST be an intentional decision grounded in the absence of real, requirement-breaking issues — later steps build on this one. A genuine blocking issue that prevents completing the step within max retries MUST be escalated as a failure, never papered over.
+- **If `STRICT_MODE` is true, this whole rule is DISABLED**: stop only when `score >= 4.0` or max retries is reached. `--strict` changes nothing else — the `4.0` target, the max-retry limit, the `< 3.0` unconditional FAIL and meta-judge/judge dispatch are unaffected.
+
 ### Phase 4: Final Summary and Report
 
 After all subtasks complete and pass verification, reply with a comprehensive report:
@@ -716,6 +745,7 @@ After all subtasks complete and pass verification, reply with a comprehensive re
 **Overall Task:** {original task description}
 **Total Steps:** {count}
 **Total Agents:** {meta_judges(one per step) + implementation_agents + judge_agents + retry_agents}
+**Strict Mode:** {STRICT_MODE}
 
 ### Step-by-Step Results
 
@@ -724,6 +754,8 @@ After all subtasks complete and pass verification, reply with a comprehensive re
 | 1 | {name} | {model} | {X.X}/5.0 | {0-3} | PASS |
 | 2 | {name} | {model} | {X.X}/5.0 | {0-3} | PASS |
 | ... | ... | ... | ... | ... | ... |
+
+Status is `PASS` (score >= 4.0), `ACCEPTED` (below target per the [Iteration Discretion Rule](#36-iteration-discretion-rule) — list the outstanding nitpicks under Follow-up Recommendations), or `FAILED`.
 
 ### Files Modified (All Steps)
 - {file1}: {what changed, which step}
@@ -756,7 +788,7 @@ One evaluation specification generated per step (in parallel with implementation
 
 ### If Judge Verification Fails (Score <4.0)
 
-The judge-verified iteration loop handles most failures automatically:
+The judge-verified iteration loop handles most failures automatically (a score in `3.0..4.0` is FAIL only after the [Iteration Discretion Rule](#36-iteration-discretion-rule) declines to accept it):
 
 ```
 Judge FAIL (Retry Available):
@@ -1348,6 +1380,7 @@ Total Agents: 20 (5 meta-judges + 5 implementations + 5 retries + 5 judges)
 - **Self-critique first:** Implementation agents verify own work before submission
 - **External judge second:** Independent judge catches blind spots self-critique misses
 - **Iteration loop:** Retry with feedback until passing or max retries
+- **Proportionate iteration:** Apply the [Iteration Discretion Rule](#36-iteration-discretion-rule) — at most ONE nitpick-driven retry, never below `3.0`, disabled by `--strict`
 - **Chain validation:** Judges check integration with previous steps
 - **Escalation:** Don't proceed past failed steps - get user input
 - **Final integration test:** After all steps, verify the complete change works together

--- a/plugins/sdd/.claude-plugin/plugin.json
+++ b/plugins/sdd/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdd",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Specification Driven Development workflow commands and agents, based on Github Spec Kit and OpenSpec. Uses specialized agents for effective context management and quality review.",
   "author": {
     "name": "Vlad Goncharov",

--- a/plugins/sdd/skills/implement-task/SKILL.md
+++ b/plugins/sdd/skills/implement-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement-task
 description: Implement a task with automated LLM-as-Judge verification per step
-argument-hint: Task file [options] (e.g., "add-validation.feature.md --continue --human-in-the-loop")
+argument-hint: Task file [--continue] [--refine] [--target-quality] [--max-iterations] [--lenient-threshold] [--strict]
 ---
 
 # Implement Task with Verification
@@ -34,6 +34,7 @@ Parse the following arguments from `$ARGUMENTS`:
 | `--max-iterations` | `--max-iterations N` | `3` | Maximum fix→verify cycles per step. Default is 3 iterations. Set to `unlimited` for no limit. |
 | `--skip-reviews` | `--skip-reviews` | `false` | Skip all per-step code-reviewer checks - steps proceed without quality gates. |
 | `--lenient-threshold` | `--lenient-threshold X.X` | `3.5` | Lenient threshold (out of 5.0) used for steps with verification level explicitly marked lenient by qa-engineer. |
+| `--strict` | `--strict` | `false` | Disable the [Iteration Discretion Rule](#iteration-discretion-rule) - a step is marked PASS ONLY when `combined_score >= threshold`, otherwise iterate until `MAX_ITERATIONS` is reached. |
 
 ### Configuration Resolution
 
@@ -61,6 +62,7 @@ SKIP_REVIEWS = --skip-reviews || false
 LENIENT_THRESHOLD = --lenient-threshold || 3.5
 REFINE_MODE = --refine || false
 CONTINUE_MODE = --continue || false
+STRICT_MODE = --strict || false
 
 # Special handling for --human-in-the-loop without step list
 if --human-in-the-loop present without step numbers:
@@ -75,7 +77,7 @@ When `--continue` is used:
    - Parse the task file for `[DONE]` markers on step titles
    - Identify the last incompleted step
    - Launch the `sdd:code-reviewer` agent to verify the last INCOMPLETE step's artifacts (using the step's `#### Verification` specification embedded in the task file)
-   - If `combined_score >= threshold` (or `>= 3.0` with only Low-priority issues): Mark step as done and resume from the next step
+   - If the step PASSES per the [Iteration Discretion Rule](#iteration-discretion-rule): Mark step as done and resume from the next step
    - Otherwise: Re-implement the step using the reviewer's issues as feedback and iterate until PASS
 
 2. **State Recovery:**
@@ -129,7 +131,7 @@ When `--refine` is used, it detects changes to **project files** (not the task f
 4. **Refine Execution:**
    - For each affected step (in order):
      - Launch the **`sdd:code-reviewer` agent** to verify the step's artifacts (including user's changes), passing the 5 standard inputs
-     - If `combined_score >= threshold` (or `>= 3.0` with only Low-priority issues): Mark step done, proceed to next
+     - If the step PASSES per the [Iteration Discretion Rule](#iteration-discretion-rule): Mark step done, proceed to next
      - Otherwise: Launch the developer agent with user's changes AND the reviewer's issues as feedback, then re-verify
    - User's manual fixes are preserved - the developer agent should build upon them, not overwrite
 
@@ -215,7 +217,7 @@ Human verification checkpoints occur:
    **Step:** {step title}
    **Verification Level:** {None / Single Judge / Panel of 2 Judges / Per-Item Judges}
    **Combined Score:** {combined_score}/5.0 (threshold: {threshold})
-   **Status:** ✅ PASS / 🔄 ITERATING (attempt {n})
+   **Status:** ✅ PASS / ☑️ ACCEPTED / 🔄 ITERATING (attempt {n})
 
    **Artifacts Created/Modified:**
    - {artifact_path_1}
@@ -316,13 +318,14 @@ Orchestrators who "quickly verify" = skip `sdd:code-reviewer` agents = quality c
 - Use `THRESHOLD_FOR_CRITICAL_COMPONENTS` (default 4.5) for steps marked as critical in the task file.
 - Use `LENIENT_THRESHOLD` (default 3.5) only when the step's verification specification explicitly marks it as lenient.
 - The threshold is applied at THIS orchestrator layer against `combined_score` returned by code-reviewer. **NEVER pass any threshold to the code-reviewer agent — or he will try to reach target score and as result become subjective.**
-- A step PASSES if `combined_score >= threshold` OR (`combined_score >= 3.0` AND every issue in code-reviewer's report has priority `Low`).
+- A step PASSES if `combined_score >= threshold`. If `3.0 <= combined_score < threshold`, the step passes ONLY when the [Iteration Discretion Rule](#iteration-discretion-rule) says so — never below its floor of `max(3.0, threshold - 1.0)`. If `combined_score < 3.0`, the step FAILS unconditionally.
 - **Default is 3 iterations** - stop after 3 fix→verify cycles and proceed to next step (with warning)!
 - If `MAX_ITERATIONS` is set to `unlimited`: Iterate until quality threshold is met (no limit)
 - Trigger human-in-the-loop checkpoints ONLY after steps in `HUMAN_IN_THE_LOOP_STEPS` (or all steps if `"*"`)!
 - **If `SKIP_REVIEWS` is true: Skip ALL code-reviewer dispatches - proceed directly to next step after each implementation completes!**
 - **If `CONTINUE_MODE` is true: Skip to `RESUME_FROM_STEP` - do not re-implement already completed steps!**
 - **If `REFINE_MODE` is true: Detect changed project files, map to steps, re-verify from `REFINE_FROM_STEP` - preserve user's fixes!**
+- **If `STRICT_MODE` is true: The [Iteration Discretion Rule](#iteration-discretion-rule) is DISABLED - a step passes ONLY on `combined_score >= threshold`, otherwise iterate until `MAX_ITERATIONS`!**
 
 ### Execution & Evaluation Rules
 
@@ -334,6 +337,23 @@ Relaunch the code-reviewer till you get valid results, if following happens:
 - Combined Score 5.0 is a Hallucination: If the code-reviewer returns a `combined_score` of 5.0/5.0, treat it as a hallucination or lazy evaluation. Reject it and re-run the agent. Perfect scores are practically impossible in this rigorous framework.
 - Reject Missing Scores: If the code-reviewer's report is missing the `combined_score` (or any sub-score: `spec_compliance_score`, `builtin_score`), reject it. This indicates the agent failed to follow the rubric instructions.
 - Reject PASS/FAIL Verdicts in Report: If the code-reviewer's output contains a PASS/FAIL verdict or references a threshold, reject it. The orchestrator owns that decision; the agent must remain threshold-blind.
+
+#### Iteration Discretion Rule
+
+Your main task is to COMPLETE the task within target quality. Two failure modes are equally real:
+
+- Burning iterations and context on nitpicks so the overall task never completes → **the task is failed**.
+- Accepting a result whose quality is genuinely too poor to be considered complete → **an even worse failure**.
+
+Apply to every step's `combined_score`:
+
+- **`combined_score < 3.0` → FAIL, unconditionally. No discretion.** Iterate with reviewer feedback until the step passes or `MAX_ITERATIONS` is reached.
+- **`3.0 <= combined_score < 5.0` → discretion band.** ONLY inside this band MAY you decide that a step below `threshold` is acceptable.
+- **Bounded drop:** NEVER accept a `combined_score` more than `1.0` below the active `threshold` — the effective floor is `max(3.0, threshold - 1.0)`: `3.5` for `THRESHOLD_FOR_CRITICAL_COMPONENTS` (4.5), `3.0` for `THRESHOLD_FOR_STANDARD_COMPONENTS` (4.0) and `LENIENT_THRESHOLD` (3.5). A `threshold <= 3.0` leaves no discretion band.
+- Inside the band, when the outstanding issues are ONLY `Low`/`Medium` priority (any `High` or `Critical` finding removes discretion entirely) AND none of them breaks a target requirement of the step or causes a meaningful defect (i.e. they are nitpicks), you MUST reason FIRST — before dispatching another iteration — about whether iterating (or marking the step failed) is worth the time and context cost.
+- **At most ONE nitpick-driven iteration**, and it counts against `MAX_ITERATIONS`. If it again surfaces only nitpicks, you MUST mark the step PASS (☑️ ACCEPTED in the summary table), report the outstanding issues in the final report, and continue with the next step. If it returns a `combined_score` below the floor `max(3.0, threshold - 1.0)`, the FAIL path applies instead.
+- You MUST be critical, NOT lenient. Stopping short of target MUST be an intentional decision grounded in the absence of real, requirement-breaking issues. A genuine blocking issue that prevents implementing the step within `MAX_ITERATIONS` MUST be reported as a failure, never papered over.
+- **If `STRICT_MODE` is true, this whole rule is DISABLED**: stop only when `combined_score >= threshold` or `MAX_ITERATIONS` is reached. `--strict` changes nothing else — thresholds, `MAX_ITERATIONS`, the `< 3.0` unconditional FAIL, human-in-the-loop checkpoints, code-reviewer dispatch and `--skip-reviews` are unaffected. With `--skip-reviews` no `combined_score` is produced at all, so both this rule and `--strict` are inert.
 
 ---
 
@@ -486,6 +506,7 @@ Parse all flags from `$ARGUMENTS` and initialize configuration.
 | **Skip Reviews** | {SKIP_REVIEWS} |
 | **Continue Mode** | {CONTINUE_MODE} |
 | **Refine Mode** | {REFINE_MODE} |
+| **Strict Mode** | {STRICT_MODE} |
 ```
 
 ### Step 0.4: Handle Continue Mode
@@ -500,7 +521,7 @@ Parse all flags from `$ARGUMENTS` and initialize configuration.
 2. **Verify Last Completed Step (if any):**
    - If `LAST_COMPLETED_STEP > 0`:
      - Launch the `sdd:code-reviewer` agent to verify the artifacts from that step (passing the 5 inputs documented in Phase 2)
-     - If reviewer's `combined_score >= threshold` (or `>= 3.0` with only Low-priority issues): Set `RESUME_FROM_STEP = LAST_COMPLETED_STEP + 1`
+     - If the step PASSES per the [Iteration Discretion Rule](#iteration-discretion-rule): Set `RESUME_FROM_STEP = LAST_COMPLETED_STEP + 1`
      - Otherwise: Set `RESUME_FROM_STEP = LAST_COMPLETED_STEP` (re-implement using reviewer feedback)
 
 3. **Skip to Resume Point:**
@@ -659,8 +680,8 @@ all_issues = reviewer.issues  (or merged issues from both reviewers in Panel)
 # PASS rule (orchestrator decides):
 if combined_score >= threshold:
     PASS
-elif combined_score >= 3.0 and every issue.priority == "Low":
-    PASS  (acceptable: minor polish only, no high/medium issues)
+elif 3.0 <= combined_score < threshold and not STRICT_MODE:
+    apply the Iteration Discretion Rule → accepted: PASS | declined: FAIL → retry
 else:
     FAIL → retry
 ```
@@ -824,7 +845,7 @@ Inputs:
 
 - Apply the orchestrator-level PASS rule:
   - PASS if `combined_score >= threshold`
-  - PASS if `combined_score >= 3.0` AND every entry in `all_issues` has `priority == "Low"`
+  - If `3.0 <= combined_score < threshold`: decide via the [Iteration Discretion Rule](#iteration-discretion-rule) using `all_issues` — accepted → PASS, declined → FAIL → retry
   - Otherwise FAIL → retry
 
 **On FAIL: Iterate Until PASS (max `MAX_ITERATIONS`, default 3)**
@@ -855,7 +876,7 @@ Inputs:
 
 **Step:** [Step Title]
 **Combined Score:** [combined_score]/5.0 (threshold: [threshold])
-**Status:** ✅ PASS
+**Status:** ✅ PASS / ☑️ ACCEPTED
 
 **Artifacts Created/Modified:**
 - [artifact_path_1]
@@ -943,7 +964,7 @@ Inputs:
 
 For each item's reviewer report, apply the orchestrator-level threshold (per the [Threshold Application](#threshold-application-orchestrator-level-only) rules — Per-Item uses `THRESHOLD_FOR_STANDARD_COMPONENTS` unless the spec marks the step lenient or critical):
 
-- PASS if `combined_score >= threshold` OR (`combined_score >= 3.0` AND every issue is Low priority)
+- PASS if `combined_score >= threshold`, or if `3.0 <= combined_score < threshold` and the [Iteration Discretion Rule](#iteration-discretion-rule) accepts the item
 - Otherwise FAIL → that specific item needs retry
 
 **6. Report Aggregate:**
@@ -979,7 +1000,7 @@ For each item's reviewer report, apply the orchestrator-level threshold (per the
 
 **Step:** [Step Title]
 **Items Passed:** X/Y
-**Status:** ✅ ALL PASS
+**Status:** ✅ ALL PASS / ☑️ ACCEPTED
 
 **Artifacts Created:**
 - [item_1_path] — combined_score: X.XX
@@ -1164,7 +1185,7 @@ Concatenate `reviewer1.issues` and `reviewer2.issues`, then de-duplicate by (des
 
 - `panel_combined_score = median(reviewer1.combined_score, reviewer2.combined_score)`
 - PASS if `panel_combined_score >= threshold`
-- PASS if `panel_combined_score >= 3.0` AND every entry in the merged issues list has `priority == "Low"`
+- If `3.0 <= panel_combined_score < threshold`: decide via the [Iteration Discretion Rule](#iteration-discretion-rule) using the merged issues list — accepted → PASS, declined → FAIL → retry
 - Otherwise FAIL → retry
 
 ---
@@ -1202,6 +1223,7 @@ After all steps complete and DoD verification passes:
 | **Skip Reviews** | {SKIP_REVIEWS} |
 | **Continue Mode** | {CONTINUE_MODE} |
 | **Refine Mode** | {REFINE_MODE} |
+| **Strict Mode** | {STRICT_MODE} |
 
 ### Steps Completed
 
@@ -1214,6 +1236,7 @@ After all steps complete and DoD verification passes:
 
 **Legend:**
 - ✅ PASS - Score >= threshold for step type
+- ☑️ ACCEPTED - Score in `max(3.0, threshold - 1.0)..threshold` accepted per the [Iteration Discretion Rule](#iteration-discretion-rule) (outstanding nitpicks listed under Recommendations)
 - ⚠️ MAX_ITER - Did not pass but MAX_ITERATIONS reached, proceeded anyway
 - ⏭️ SKIPPED - Step skipped (continue/refine mode)
 
@@ -1222,6 +1245,7 @@ After all steps complete and DoD verification passes:
 - Total steps: X
 - Steps with verification: Y
 - Passed on first try: Z
+- Accepted below target per Iteration Discretion Rule: U (outstanding nitpicks listed under Recommendations)
 - Required iteration: W
 - Total iterations across all steps: V
 - Final pass rate: 100%
@@ -1384,6 +1408,9 @@ After all steps complete and DoD verification passes:
 # Custom lenient threshold for steps marked lenient by qa-engineer
 /implement add-validation.feature.md --lenient-threshold 3.0
 
+# Strict mode: never accept a step below target - iterate until threshold or MAX_ITERATIONS
+/implement add-validation.feature.md --strict
+
 # Combined: continue with human review
 /implement add-validation.feature.md --continue --human-in-the-loop
 ```
@@ -1422,8 +1449,18 @@ Step 2: Launching sdd:developer agent...
   Launching 2 sdd:code-reviewer agents in parallel (Panel of 2)...
   Reviewer 1: combined_score 4.3/5.0
   Reviewer 2: combined_score 4.5/5.0
-  Panel median: 4.4/5.0 (threshold 4.5) — issues all Low priority → PASS ✅
-  Status: ✅ COMPLETE (Reviewer Confirmed)
+  Panel median: 4.4/5.0 (threshold 4.5, floor max(3.0, 4.5-1.0) = 3.5)
+  Reasoning (Iteration Discretion Rule, before dispatching an iteration):
+    - 4.4 is inside 3.0..5.0 and above the 3.5 floor → discretion available
+    - 2 outstanding findings, both Low, no High/Critical, no requirement broken
+    - no nitpick-driven iteration spent yet → spend the ONE allowed iteration
+  Iteration 1/3: Re-launching sdd:developer with reviewer feedback...
+  Re-launching Panel of 2...
+  Panel median: 4.4/5.0 — same 2 Low findings, unchanged
+  Reasoning: the one allowed nitpick-driven iteration is now spent and it
+    surfaced only the same nitpicks; 4.4 is still above the 3.5 floor
+    → stop, do not iterate again
+  Status: ☑️ ACCEPTED (2 outstanding nitpicks reported under Recommendations)
 
 [Continue for all steps...]
 
@@ -1717,6 +1754,9 @@ Before completing implementation:
 - [ ] Used `THRESHOLD_FOR_CRITICAL_COMPONENTS` for `Panel of 2 Judges` steps
 - [ ] Used `LENIENT_THRESHOLD` only for steps the qa-engineer's spec marks lenient
 - [ ] Iterated until orchestrator-level PASS rule satisfied (or `MAX_ITERATIONS` reached, default 3)
+- [ ] Applied the [Iteration Discretion Rule](#iteration-discretion-rule) only inside `3.0 <= combined_score < 5.0`, never accepted below `max(3.0, threshold - 1.0)`, treated `< 3.0` as unconditional FAIL, and spent at most ONE nitpick-driven iteration
+- [ ] Passed NO threshold, floor or band value to the code-reviewer — the agent stayed threshold-blind
+- [ ] If `STRICT_MODE` is true: Ignored the Iteration Discretion Rule and iterated until `threshold` or `MAX_ITERATIONS`
 - [ ] Triggered human-in-the-loop checkpoints ONLY for steps in `HUMAN_IN_THE_LOOP_STEPS`
 - [ ] If `SKIP_REVIEWS` is true: Skipped ALL code-reviewer dispatches
 - [ ] If `CONTINUE_MODE` is true: Verified last step (via code-reviewer) and resumed correctly

--- a/plugins/sdd/skills/plan-task/SKILL.md
+++ b/plugins/sdd/skills/plan-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-task
 description: Refine, parallelize, and verify a draft task specification into a fully planned implementation-ready task
-argument-hint: Path to draft task file (e.g., ".specs/tasks/draft/add-validation.feature.md") [options]
+argument-hint: Path to draft task file (e.g., ".specs/tasks/draft/add-validation.feature.md") [--continue] [--refine] [--target-quality] [--max-iterations] [--included-stages] [--skip] [--fast] [--strict] [--model opus|sonnet|haiku]
 ---
 
 # Refine Task Workflow
@@ -50,6 +50,8 @@ Parse the following arguments from `$ARGUMENTS`:
 | `--human-in-the-loop` | `--human-in-the-loop phase1,phase2,...` | None | Phases after which to pause for human verification. |
 | `--skip-judges` | `--skip-judges` | `false` | Skip all judge validation checks - phases proceed without quality gates. |
 | `--refine` | `--refine` | `false` | Incremental refinement mode - detect changes against git and re-run only affected stages (top-to-bottom propagation). |
+| `--model` | `opus|sonnet|haiku` | `opus` | Model to use for the agents and judges |
+| `--strict` | `--strict` | `false` | Disable the [Iteration Discretion Rule](#iteration-discretion-rule) - a phase passes ONLY when `score >= THRESHOLD`, otherwise retry until `MAX_ITERATIONS` is reached. |
 
 ### Stage Names (for `--included-stages` / `--skip`)
 
@@ -90,6 +92,7 @@ SKIP_STAGES = --skip || []
 HUMAN_IN_THE_LOOP_PHASES = --human-in-the-loop || []
 SKIP_JUDGES = --skip-judges || false
 REFINE_MODE = --refine || false
+STRICT_MODE = --strict || false
 CONTINUE_STAGE = null
 
 if --continue [stage] present:
@@ -175,7 +178,7 @@ Human verification checkpoints occur:
 
    **Phase:** {phase name}
    **Judge Score:** {score}/{THRESHOLD} threshold
-   **Status:** ✅ PASS / ⚠️ RETRY {n}/{MAX_ITERATIONS}
+   **Status:** ✅ PASS / ☑️ ACCEPTED / ⚠️ RETRY {n}/{MAX_ITERATIONS}
 
    **Artifacts:**
    - {artifact_path_1}
@@ -209,6 +212,9 @@ Human verification checkpoints occur:
 
 # Incremental refinement after user edits (re-runs only affected stages)
 /plan .specs/tasks/todo/my-task.feature.md --refine
+
+# Strict mode: never accept a phase below target - retry until THRESHOLD or MAX_ITERATIONS
+/plan .specs/tasks/draft/critical-api.feature.md --strict
 ```
 
 ## Pre-Flight Checks
@@ -234,6 +240,7 @@ Before starting workflow:
    | **Human Checkpoints** | Phase {HUMAN_IN_THE_LOOP_PHASES as comma-separated} |
    | **Skip Judges** | {SKIP_JUDGES} |
    | **Refine Mode** | {REFINE_MODE} |
+   | **Strict Mode** | {STRICT_MODE} |
    | **Continue From** | {CONTINUE_STAGE} or "Start" |
    ```
 
@@ -326,7 +333,7 @@ Update each todo to `in_progress` when starting a phase and `completed` when jud
 
 ## CRITICAL
 
-- Do not mark PASS for any judge if it did not pass the rubric. Retry the judge after each implementation change till it passes the check!
+- Never record a verdict the judge report does not support: no PASS without a passing rubric result, and no ☑️ ACCEPTED without the [Iteration Discretion Rule](#iteration-discretion-rule) actually permitting it. Otherwise retry the judge after each implementation change till it passes the check!
 - Do not read task files in .claude or .specs directories, your job is orchestrate agents that will do the work, not do it by yourself!
 - Use `THRESHOLD` (default 3.5) for all judge pass/fail decisions, not hardcoded values!
 - Use `MAX_ITERATIONS` (default 3) for retry limits, not hardcoded values!
@@ -336,6 +343,7 @@ Update each todo to `in_progress` when starting a phase and `completed` when jud
 - **If `SKIP_JUDGES` is true: Skip ALL judge validation - proceed directly to next phase after each implementation phase completes!**
 - **Task file must exist in `.specs/tasks/draft/` before running this command (unless `--refine` mode)!**
 - **If `REFINE_MODE` is true: Detect changes via git diff, skip unchanged stages, pass user feedback to agents!**
+- **If `STRICT_MODE` is true: The [Iteration Discretion Rule](#iteration-discretion-rule) is DISABLED - a phase passes ONLY on `score >= THRESHOLD`, otherwise retry until `MAX_ITERATIONS`!**
 
 ### Execution & Evaluation Rules
 
@@ -346,6 +354,23 @@ Relaunch judge till you get valid results, of following happens:
 - Reject Long Reports: If an agent returns a very long report instead of using the scratchpad as requested, reject the result. This indicates the agent failed to follow the "use scratchpad" instruction.
 - Judge Score 5.0 is a Hallucination: If a judge returns a score of 5.0/5.0, treat it as a hallucination or lazy evaluation. Reject it and re-run the judge. Perfect scores are practically impossible in this rigorous framework.
 - Reject Missing Scores: If a judge report is missing the numerical score, reject it. This indicates the judge failed to read or follow the rubric instructions.
+
+#### Iteration Discretion Rule
+
+Your main task is to COMPLETE the planning within target quality. Two failure modes are equally real:
+
+- Burning iterations and context on nitpicks so the overall task never completes → **the task is failed**.
+- Promoting a plan whose quality is genuinely too poor to be considered complete → **an even worse failure**.
+
+This rule governs the `**Decision Logic:**` block of every phase:
+
+- **`score < 3.0` → FAIL, unconditionally. No discretion.** Re-launch the phase with judge feedback until it passes or `MAX_ITERATIONS` is reached.
+- **`3.0 <= score < 5.0` → discretion band.** ONLY inside this band MAY you decide that a phase below `THRESHOLD` (default 3.5) is acceptable.
+- **Bounded drop:** NEVER accept a score more than `1.0` below `THRESHOLD` — the effective floor is `max(3.0, THRESHOLD - 1.0)`, i.e. `3.0` at the default `THRESHOLD` 3.5 and `3.5` at `--target-quality 4.5`. With `THRESHOLD <= 3.0` (e.g. `--fast`) there is no discretion band at all.
+- Inside the band, when the outstanding issues are ONLY `Low`/`Medium` priority (any `High` or `Critical` finding removes discretion entirely) AND none of them breaks a target requirement of the phase or causes a meaningful defect (i.e. they are nitpicks), you MUST reason FIRST — before re-launching the phase — about whether iterating (or marking the phase failed) is worth the time and context cost.
+- **At most ONE nitpick-driven iteration**, and it counts against `MAX_ITERATIONS`. If it again surfaces only nitpicks, you MUST mark the phase PASS (☑️ ACCEPTED in the summary table), report the outstanding issues in the completion summary, and continue with the next phase. If it returns a score below the floor `max(3.0, THRESHOLD - 1.0)`, the FAIL path applies instead.
+- You MUST be critical, NOT lenient. Stopping short of target MUST be an intentional decision grounded in the absence of real, requirement-breaking issues. A genuine blocking issue that prevents completing the phase within `MAX_ITERATIONS` MUST be reported as a failure, never papered over.
+- **If `STRICT_MODE` is true, this whole rule is DISABLED**: stop only when `score >= THRESHOLD` or `MAX_ITERATIONS` is reached. `--strict` changes nothing else — `THRESHOLD`, `MAX_ITERATIONS`, the `< 3.0` unconditional FAIL, human-in-the-loop checkpoints, judge dispatch and `--skip-judges` are unaffected. With `--skip-judges` (or `--one-shot`) no score is produced at all, so both this rule and `--strict` are inert.
 
 ## Workflow Execution
 
@@ -574,7 +599,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Research complete, proceed
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 2a with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 2a with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Proceed to next stage regardless of score (log warning)
 
 ---
@@ -628,7 +653,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Analysis complete, proceed
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 2b with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 2b with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Proceed to next stage regardless of score (log warning)
 
 ---
@@ -683,7 +708,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Business analysis complete, proceed
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 2c with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 2c with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Proceed to next stage regardless of score (log warning)
 
 ---
@@ -779,7 +804,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Architecture synthesis complete, proceed
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 3 with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 3 with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Proceed to Phase 4 regardless of score (log warning)
 
 **Wait for PASS before Phase 4.**
@@ -872,7 +897,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Decomposition complete, proceed to Phase 5
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 4 with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 4 with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Proceed to Phase 5 regardless of score (log warning)
 
 **Wait for PASS before Phase 5.**
@@ -966,7 +991,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Proceed to Phase 6
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 5 with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 5 with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Proceed to Phase 6 regardless of score (log warning)
 
 **Wait for PASS before Phase 6.**
@@ -1061,7 +1086,7 @@ CRITICAL: use prompt exactly as is, do not add anything else. Including output o
 **Decision Logic:**
 
 - **PASS** (score >= `THRESHOLD`): Workflow complete, promote task
-- **FAIL** (score < `THRESHOLD`): Re-launch Phase 6 with feedback
+- **FAIL** (score < `THRESHOLD`): Re-launch Phase 6 with feedback (unless accepted per the [Iteration Discretion Rule](#iteration-discretion-rule))
 - **MAX_ITERATIONS reached**: Complete workflow regardless of score (log warning)
 
 ---
@@ -1118,25 +1143,31 @@ After all executed phases and judges complete:
 | **Human Checkpoints** | Phase {HUMAN_IN_THE_LOOP_PHASES as comma-separated} |
 | **Skip Judges** | {SKIP_JUDGES} |
 | **Refine Mode** | {REFINE_MODE} |
+| **Strict Mode** | {STRICT_MODE} |
 
 ### Quality Gates Summary
 
 | Phase | Judge Score | Verdict |
 |-------|-------------|---------|
-| Phase 2a: Research | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
-| Phase 2b: Codebase Analysis | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
-| Phase 2c: Business Analysis | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
-| Phase 3: Architecture Synthesis | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
-| Phase 4: Decomposition | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
-| Phase 5: Parallelize | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
-| Phase 6: Verify | X.X/5.0 | ✅ PASS / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 2a: Research | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 2b: Codebase Analysis | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 2c: Business Analysis | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 3: Architecture Synthesis | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 4: Decomposition | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 5: Parallelize | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
+| Phase 6: Verify | X.X/5.0 | ✅ PASS / ☑️ ACCEPTED / ⚠️ PROCEEDED (max iter) / ⏭️ SKIPPED |
 
 **Threshold Used:** {THRESHOLD}/5.0 (or N/A if SKIP_JUDGES)
 
 **Legend:**
 - ✅ PASS - Score >= THRESHOLD
+- ☑️ ACCEPTED - Score in `max(3.0, THRESHOLD - 1.0)..THRESHOLD` accepted per the [Iteration Discretion Rule](#iteration-discretion-rule) (outstanding nitpicks listed below the table)
 - ⚠️ PROCEEDED (max iter) - Score < THRESHOLD but MAX_ITERATIONS reached, proceeded anyway
 - ⏭️ SKIPPED - Stage not in ACTIVE_STAGES
+
+**Outstanding Issues (accepted below THRESHOLD):**
+
+{For each ☑️ ACCEPTED phase: phase, remaining nitpicks with priority — omit this block when no phase was accepted}
 
 ### Artifacts Generated
 
@@ -1194,6 +1225,7 @@ If any phase agent fails unexpectedly:
 
 If any judge returns FAIL (score < `THRESHOLD`):
 
+0. **Apply the [Iteration Discretion Rule](#iteration-discretion-rule) first**: if `score < 3.0` (or `STRICT_MODE` is true), always retry. If `max(3.0, THRESHOLD - 1.0) <= score < THRESHOLD` and only nitpicks remain, decide deliberately whether retrying is worth it — if you accept, mark the phase ☑️ ACCEPTED, list its outstanding nitpicks in the summary, and proceed to the next phase instead of steps 1-4; otherwise continue with step 1
 1. **Automatic retry**: Re-launch the phase agent with judge feedback
 2. **Human-in-the-loop check**: If phase is in `HUMAN_IN_THE_LOOP_PHASES`, trigger human checkpoint **before** the next judge retry (after implementation retry but before re-judging)
 3. **After `MAX_ITERATIONS` reached**: **Proceed to next stage automatically** (do NOT ask user unless `--human-in-the-loop` includes this phase)


### PR DESCRIPTION
Latest versions of Opus and Fable is too critical during iteration cycles, which results in unnesesary iterations over simple nitpicks. 
New logic adds a way for orcestrator to skip certan iterations, and accept score below target, when it meangful enough